### PR TITLE
Use print function for transcription message

### DIFF
--- a/phonetics.py
+++ b/phonetics.py
@@ -61,7 +61,7 @@ def get_phonetic_transcription(text, language='en-us', output_fname=None):
         fname2 = output_fname
 
     if output_fname is None or not os.path.exists(fname2):
-        print "Transcribing: %s" % fname2
+        print("Transcribing: %s" % fname2)
         fname = u'temp_lyrics.txt'
         f = codecs.open(fname, 'w', 'utf8')
         f.write(text)


### PR DESCRIPTION
## Summary
- use Python 3 print function when reporting transcription file name

## Testing
- `python -m py_compile phonetics.py`


------
https://chatgpt.com/codex/tasks/task_b_68b76e668440832886bb8dcb981ec1a1